### PR TITLE
Make sure our current tests are all passing.

### DIFF
--- a/backend/Posts/tests.py
+++ b/backend/Posts/tests.py
@@ -39,7 +39,6 @@ class PostTestCase(TestCase):
         data = { 'title': 'CS Classes', 'message': 'What CS classes should I take?','hub': 'CS' }
         response = self.client.post(reverse('post-create'), data, format='json')
         
-        print(response.data)  
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)  
         self.assertEqual(Post.objects.count(), 3)  
 
@@ -95,7 +94,7 @@ class PostTestCase(TestCase):
         self.client.logout()
         url = reverse('post-delete', kwargs={'post_id': self.post1.id})
         resp = self.client.delete(url)
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, "Unauthenticated user is deleting post")
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED, "Unauthenticated user is deleting post")
         post_exists = Post.objects.filter(id=self.post1.id).exists()
         self.assertTrue(post_exists, "This post was deleted by an unauthenticated user")
 

--- a/backend/hubs/tests.py
+++ b/backend/hubs/tests.py
@@ -284,7 +284,7 @@ class HubAPITests(APITestCase):
         
         
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN) #403 forbidden since user is not authorized
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED) #401 since user is not authorized
         self.assertEqual(Hub.objects.count(), 0) #make sure hub never got created
 
     def test_delete_hub(self):


### PR DESCRIPTION
testing oriented
backend

files updated
`backend/Posts/tests.py`
`backend/hubs/tests.py`

I believe that when the users api got merged into our project it changed one of the response codes for a generic view or serializer. I'm not too sure what caused the change in status code but when me and aarush were originally writing our tests it seems we were expecting a status code for 403 but after adding in users it's actually a 401. 401 seems more appropriate anyways so whatever change happened i think it's good. 

the current tests we have where 2 are failing.
![image](https://github.com/user-attachments/assets/34918bfd-33ac-45dc-9b03-fe9cc1449c6d)

updated tests to expect 401 now. all passing
![image](https://github.com/user-attachments/assets/c96d6fad-a056-465d-9d5f-09a29ce60568)

All i did was change the two lines in the tests that were expecting a 403 and changed it to 401. I also removed a print statement from one of the test cases as it can be misleading/confusing if it comes up in any reports. I'm sorry for not structuring this pull request, I'll make sure to follow the standard once our template gets confirmed.