### PR TITLE
Language Filter

### DIFF
--- a/backend/Comments/filter.py
+++ b/backend/Comments/filter.py
@@ -3,7 +3,7 @@
 def inappropriate_language_filter(message):
     # Notes: Does not matter if the word is uppercase or lowercase
     # Also, crap will be used as an example
-    disallowed_words = ["fuck", "bitch", "asshole", "shit","crap"]  
+    disallowed_words = ["fuck", "bitch", "ass", "shit","crap"]  
     for word in disallowed_words:
         if word in message.lower():
             return True

--- a/backend/Comments/filter.py
+++ b/backend/Comments/filter.py
@@ -1,0 +1,10 @@
+# Comments/filter.py
+# Language Filter for inappropriate language
+def inappropriate_language_filter(message):
+    # Notes: Does not matter if the word is uppercase or lowercase
+    # Also, crap will be used as an example
+    disallowed_words = ["fuck", "bitch", "asshole", "shit","crap"]  
+    for word in disallowed_words:
+        if word in message.lower():
+            return True
+    return False

--- a/backend/Comments/serializers.py
+++ b/backend/Comments/serializers.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import PermissionDenied
 from .models import Comment
 from rest_framework.exceptions import ValidationError
 from Posts.models import Post
-from .filter import inappropriate_language_filter
+from Comments.filter import inappropriate_language_filter
 
 # To serilize the comment        
 class CommentSerializer(serializers.ModelSerializer):
@@ -40,6 +40,7 @@ class CommentSerializer(serializers.ModelSerializer):
         if inappropriate_language_filter(value):
             raise serializers.ValidationError("Inappropriate language is not allowed.")
         return value
+    
  # Serializer for creating any new comments
 class CommentCreateSerializer(serializers.ModelSerializer):
     post_id = serializers.IntegerField(write_only=True) 
@@ -54,10 +55,13 @@ class CommentCreateSerializer(serializers.ModelSerializer):
         comment_reply = data.get('comment_reply')
 
         # Post associated with the given ID
+        if inappropriate_language_filter(data.get('message')):
+            raise ValidationError("Your comment contains inappropriate language and cannot be posted.")
+
         if comment_reply and comment_reply.post != post:
             raise ValidationError("Reply must be linked to a comment under the same post.")
         return data
-
+    
     # Create a new Comment instance using validated data
     def create(self, validated_data):
         return Comment.objects.create(**validated_data)

--- a/backend/Comments/serializers.py
+++ b/backend/Comments/serializers.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import PermissionDenied
 from .models import Comment
 from rest_framework.exceptions import ValidationError
 from Posts.models import Post
+from .filter import inappropriate_language_filter
 
 # To serilize the comment        
 class CommentSerializer(serializers.ModelSerializer):
@@ -35,6 +36,10 @@ class CommentSerializer(serializers.ModelSerializer):
         representation['is_disliked'] = user in instance.dislikes.all()
         return representation
     
+    def validate_message(self, value):
+        if inappropriate_language_filter(value):
+            raise serializers.ValidationError("Inappropriate language is not allowed.")
+        return value
  # Serializer for creating any new comments
 class CommentCreateSerializer(serializers.ModelSerializer):
     post_id = serializers.IntegerField(write_only=True) 

--- a/backend/Comments/tests.py
+++ b/backend/Comments/tests.py
@@ -165,3 +165,5 @@ class CommentViewTestsCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)  
+        
+        

--- a/backend/Comments/tests.py
+++ b/backend/Comments/tests.py
@@ -9,6 +9,7 @@ from Comments.serializers import CommentSerializer, CommentCreateSerializer, Lik
 from rest_framework.test import APITestCase, APIClient, APIRequestFactory
 from django.urls import reverse
 from rest_framework import status
+from Comments.filter import inappropriate_language_filter
 
 
 # Test cases for Modles.py

--- a/backend/Comments/views.py
+++ b/backend/Comments/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from Posts.models import Post
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from django.db.models import Count
+from .utils import inappropriate_language_filter
 # Create your views here.
  
  # Creating a comment  

--- a/backend/Comments/views.py
+++ b/backend/Comments/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from Posts.models import Post
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from django.db.models import Count
-from .utils import inappropriate_language_filter
+from Comments.filter import inappropriate_language_filter
 # Create your views here.
  
  # Creating a comment  
@@ -127,13 +127,3 @@ class DislikeComment(generics.UpdateAPIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response({'likes': comment.likes.count(), 'dislikes': comment.dislikes.count()}, status=status.HTTP_200_OK)
-
-# Language Filter for inappropriate language
-def inappropriate_language_filter(message):
-    # Notes: Does not matter if the word is uppercase or lowercase
-    # Also, crap will be used as an example
-    disallowed_words = ["fuck", "bitch", "asshole", "shit","crap"]  
-    for word in disallowed_words:
-        if word in message.lower():
-            return True
-    return False

--- a/backend/Comments/views.py
+++ b/backend/Comments/views.py
@@ -20,13 +20,24 @@ class CommentCreate(generics.CreateAPIView):
         comment_reply_id = self.request.data.get('comment_reply_id')
         serializer.save(author=self.request.user, post_id=post_id, comment_reply_id=comment_reply_id)
         
+        message = serializer.validated_data.get('message', '')
+        if inappropriate_language_filter(message):
+            raise ValidationError("Any inappropriate language is not allowed.")
 
+        serializer.save(author=self.request.user, post_id=post_id, comment_reply_id=comment_reply_id)
+        
 # Creating a reply       
 class CommentReplyCreate(generics.CreateAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = CommentCreateSerializer  
     def perform_create(self, serializer):
         comment_id = self.kwargs['comment_id']
+        serializer.save(author=self.request.user, comment_reply_id=comment_id)
+        
+        message = serializer.validated_data.get('message', '')
+        if inappropriate_language_filter(message):
+            raise ValidationError("Any inappropriate language is not allowed.")
+
         serializer.save(author=self.request.user, comment_reply_id=comment_id)
         
 # Using to timestamp to order the comments or can order by most likes

--- a/backend/Comments/views.py
+++ b/backend/Comments/views.py
@@ -20,6 +20,7 @@ class CommentCreate(generics.CreateAPIView):
         comment_reply_id = self.request.data.get('comment_reply_id')
         serializer.save(author=self.request.user, post_id=post_id, comment_reply_id=comment_reply_id)
         
+
 # Creating a reply       
 class CommentReplyCreate(generics.CreateAPIView):
     permission_classes = [IsAuthenticated]
@@ -114,3 +115,13 @@ class DislikeComment(generics.UpdateAPIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response({'likes': comment.likes.count(), 'dislikes': comment.dislikes.count()}, status=status.HTTP_200_OK)
+
+# Language Filter for inappropriate language
+def inappropriate_language_filter(message):
+    # Notes: Does not matter if the word is uppercase or lowercase
+    # Also, crap will be used as an example
+    disallowed_words = ["fuck", "bitch", "asshole", "shit","crap"]  
+    for word in disallowed_words:
+        if word in message.lower():
+            return True
+    return False

--- a/backend/Posts/filter.py
+++ b/backend/Posts/filter.py
@@ -3,7 +3,7 @@
 def inappropriate_language_filter(message):
     # Notes: Does not matter if the word is uppercase or lowercase
     # Also, crap will be used as an example
-    disallowed_words = ["fuck", "bitch", "asshole", "shit","crap"]  
+    disallowed_words = ["fuck", "bitch", "ass", "shit","crap"]  
     for word in disallowed_words:
         if word in message.lower():
             return True

--- a/backend/Posts/filter.py
+++ b/backend/Posts/filter.py
@@ -1,0 +1,10 @@
+# Comments/filter.py
+# Language Filter for inappropriate language
+def inappropriate_language_filter(message):
+    # Notes: Does not matter if the word is uppercase or lowercase
+    # Also, crap will be used as an example
+    disallowed_words = ["fuck", "bitch", "asshole", "shit","crap"]  
+    for word in disallowed_words:
+        if word in message.lower():
+            return True
+    return False

--- a/backend/Posts/serializers.py
+++ b/backend/Posts/serializers.py
@@ -41,15 +41,17 @@ class PostCreateSerializer(serializers.ModelSerializer):
         model = Post
         fields = ['id', 'title', 'message', 'hub_id']
 
-    def validate_message(self, value):
-        if inappropriate_language_filter(value):
-            raise serializers.ValidationError("Your post contains inappropriate language.")
-        return value
     
     def validate(self, data):
         request = self.context.get('request')
         user = request.user
         hub_id = data.get('hub_id')
+        
+        if inappropriate_language_filter(data.get('title', '')):
+            raise serializers.ValidationError("Your post title contains inappropriate language.")
+        if inappropriate_language_filter(data.get('message', '')):
+            raise serializers.ValidationError("Your post message contains inappropriate language.")
+
         try:
             hub = Hub.objects.get(id=hub_id)
         except Hub.DoesNotExist:
@@ -141,7 +143,12 @@ class PostEditSerializer(serializers.ModelSerializer):
         request = self.context.get('request')
         user = request.user
         post = self.instance
-
+        
+        if inappropriate_language_filter(data.get('title', '')):
+            raise serializers.ValidationError("Inappropriate language in the title.")
+        if inappropriate_language_filter(data.get('message', '')):
+            raise serializers.ValidationError("Inappropriate language in the message.")
+        
         if user != post.author:
             raise PermissionDenied("User does not have permission to update post")
 

--- a/backend/Posts/serializers.py
+++ b/backend/Posts/serializers.py
@@ -6,6 +6,7 @@ from hubs.models import Hub
 from Pictures.models import Picture
 from Comments.serializers import CommentSerializer
 from django.contrib.auth.models import User
+from Posts.filter import inappropriate_language_filter
 
 # To serialise the post which validates data from the front end
 class PostSerializer(serializers.ModelSerializer):
@@ -40,6 +41,11 @@ class PostCreateSerializer(serializers.ModelSerializer):
         model = Post
         fields = ['id', 'title', 'message', 'hub_id']
 
+    def validate_message(self, value):
+        if inappropriate_language_filter(value):
+            raise serializers.ValidationError("Your post contains inappropriate language.")
+        return value
+    
     def validate(self, data):
         request = self.context.get('request')
         user = request.user

--- a/backend/Profile/serializers.py
+++ b/backend/Profile/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import Profile
-
+from hubs.filter import inappropriate_language_filter 
 class ProfileSerializer(serializers.ModelSerializer):
     # hubs_count = serializers.ReadOnlyField(source='hubs_count')  
 
@@ -15,4 +15,13 @@ class ProfileSerializer(serializers.ModelSerializer):
         instance.pfp = validated_data.get('pfp', instance.pfp)
         instance.save()
         return instance
+
+    def validate_bio(self, value):
+        if inappropriate_language_filter(value):
+            raise serializers.ValidationError("Inappropriate language is not allowed in your bio.")
+        return value
     
+    def validate_name(self, value):
+        if inappropriate_language_filter(value):
+            raise serializers.ValidationError("Inappropriate language is not allowed for your name.")
+        return value

--- a/backend/hubs/filter.py
+++ b/backend/hubs/filter.py
@@ -1,0 +1,10 @@
+# Comments/filter.py
+# Language Filter for inappropriate language
+def inappropriate_language_filter(message):
+    # Notes: Does not matter if the word is uppercase or lowercase
+    # Also, crap will be used as an example
+    disallowed_words = ["fuck", "bitch", "ass", "shit","crap"]  
+    for word in disallowed_words:
+        if word in message.lower():
+            return True
+    return False

--- a/backend/hubs/serializers.py
+++ b/backend/hubs/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from django.contrib.auth.models import User
 from .models import Hub
-
+from hubs.filter import inappropriate_language_filter 
 #Serializer for a Hub model with all fields included.
 #This serializer represents a hub
 class HubSerializer(serializers.ModelSerializer):
@@ -48,6 +48,16 @@ class HubCreateSerializer(serializers.ModelSerializer):
         model = Hub
         fields = ['id', 'name', 'description', 'private_hub']
 
+    def validate_name(self, value):
+        if inappropriate_language_filter(value):
+            raise serializers.ValidationError("Inappropriate language is not allowed in the hub name.")
+        return value
+
+    def validate_description(self, value):
+        if inappropriate_language_filter(value):
+            raise serializers.ValidationError("Inappropriate language is not allowed in the hub description.")
+        return value
+    
     def create(self, validated_data):
         request = self.context.get('request')
         user = request.user

--- a/frontend/src/components/comments/forms/CreateCommentForm.tsx
+++ b/frontend/src/components/comments/forms/CreateCommentForm.tsx
@@ -8,6 +8,7 @@ import { getCreateCommentsUrl, getCreateReplyUrl } from "@/utils/url-segments";
 import { FormProvider, useForm } from "react-hook-form";
 import styles from "./CreateCommentForm.module.css";
 import bStyles from "@/components/posts/buttons/post-buttons.module.css";
+import { useState } from "react";
 
 interface ComponentProps {
     post: Post;
@@ -29,6 +30,7 @@ interface ComponentProps {
 
 const CreateCommentForm: React.FC<ComponentProps> = ({ post, onClose, commentReply=null, parentCreate }) => {
     const methods = useForm();
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const onSubmit = methods.handleSubmit(async data => {
         try {
@@ -60,13 +62,20 @@ const CreateCommentForm: React.FC<ComponentProps> = ({ post, onClose, commentRep
             }
 
             methods.reset();
-
+            setErrorMessage(null);
             // Use function to add comment to the hooks
             parentCreate(response.data);
             onClose();
 
-        } catch (error) {
-            alert("There was an error in your comment: " + error);
+        } catch (error: any) {
+            if (error.response && error.response.status === 400) {
+                // Check for backend error messages
+                setErrorMessage(error.response.data.detail || "Inappropriate language detected.");
+            } else {
+                setErrorMessage("An unexpected error occurred. Please try again.");
+            }
+
+            
             console.log(error);
 
             //If the comment's reply/post was deleted, reload the page
@@ -85,6 +94,8 @@ const CreateCommentForm: React.FC<ComponentProps> = ({ post, onClose, commentRep
                 noValidate
             >
                 <div className={styles.commentInputContainer}>
+                    {errorMessage && <div className={styles.errorMessage}>{errorMessage}</div>}
+                    
                     <CreateInput {...COMMENT_VALIDATION} />
                     
                     <div className={styles.commentButtonContainer}>

--- a/frontend/src/components/hubs/HubCreate.js
+++ b/frontend/src/components/hubs/HubCreate.js
@@ -99,7 +99,7 @@ const HubCreate = () => {
 							     setNameErrorMessage("");
 						  	     setHubName(text.target.value);} }
 				/>
-				{nameError && <p> {nameErrorMessage} </p> }
+				{nameError && <p style={{ marginTop: '1rem'}}> {nameErrorMessage} </p> }
 				<h2 className={styles.createDescHeader} > Hub Description </h2>
 				<textarea 
 					className={styles.createDescInput}

--- a/frontend/src/components/posts/forms/create-post-form.tsx
+++ b/frontend/src/components/posts/forms/create-post-form.tsx
@@ -20,7 +20,8 @@ const CreatePostForm: FC = () => {
             image: null,
         }
     });
-
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    
     const router = useRouter();
 
     const onSubmit = methods.handleSubmit(async data => {
@@ -78,12 +79,18 @@ const CreatePostForm: FC = () => {
             }
 
             methods.reset();
-
+            setErrorMessage(null);
             // Try to send the user to the newly created post
             router.push(URL_SEGMENTS.FRONTEND + URL_SEGMENTS.POSTS_HOME + postResponse.data.id);
 
-        } catch (error) {
-            alert("There was an error in your form: " + error);
+        } catch (error: any) {
+            if (error.response && error.response.status === 400) {
+                setErrorMessage(error.response.data.detail || "Inappropriate language detected. Please refrain from using inappropriate language");
+            } else {
+                setErrorMessage("An unexpected error occurred. Please try again.");
+            }
+
+            console.error(error);
             return null;
         }
     })
@@ -98,6 +105,7 @@ const CreatePostForm: FC = () => {
                     <h1>Create a Post</h1>
                 </div>
                 <div className={styles.createPostContainer}>
+                    {errorMessage && <div className={styles.errorMessage}>{errorMessage}</div>}
                     <CreateInput {...TITLE_VALIDATION} />
                     <HubInput />
                     <CreateInput {...POST_MESSAGE_VALIDATION} />


### PR DESCRIPTION
*Please complete the checklist so the group can quickly understand your PR.*

### Category
- [x] **Feature**
- [ ] **Bug Fix**
- [ ] **Testing**
- [ ] **Documentation**
- [ ] **Other**

### Domain
- [ ] **Frontend**
- [ ] **Backend**
- [x] **Both**

### Description
Providing a language filter to any messages, comments, descriptions, names, bio, and titles. This filter stops inappropriate words from being used in places like for the profile, comments, posts, and hubs.

### Related Issue(s)
#87 "Language Filter Needed"

### New Additions
-Comment/filter.py (Holds the inappropriate_language_filter function)
- Posts/filter.py (Holds the inappropriate_language_filter function)
- Hubs/filter.py (Holds the inappropriate_language_filter function)

### Modifications
- Comment/serializers.py (Validating that appropriate language is being used in comments and replies)
-  Comment/test.py (Checking test cases)
- Posts/serializers.py (Validating that appropriate language is being used in the post title and message)
- Hubs/serializers.py (Validating that appropriate language is being used in Hub name and description)
- Profile /serializers.py (Validating that appropriate language is being used in user profile bio and name)

### New Dependencies
None

### Visuals

Here is an example of a set of you can do, with the inappropriate word being "crap":


![image](https://github.com/user-attachments/assets/4e5bc2cc-a570-46d4-8d7e-107b14cea0a5)
![q2](https://github.com/user-attachments/assets/39a59d07-b229-4700-bc23-07a7f0881a11)

 Above are two images that give two separate errors. One if you use bad words in the bio, and the other is if it's in the name. You can also try doing this with, posts, hubs, and comments.


![image](https://github.com/user-attachments/assets/3ae52512-9203-4049-86c3-6ce742602412)
Example of using "crap" and getting an error message in comments.


![image](https://github.com/user-attachments/assets/ad37b3ad-aa11-438b-8e8c-de8e346081b4)
Here's what Hubs looks like with an error message by adding "Crappy", it also works if you just do "crap".


### Architecture of Your Changes
Users who interact with Posts, Messages, their profile, and Hubs, won't be able to use inappropriate language due to an added validation check in the serializer.py files

No other modifications to the existing system, only improvements to test coverage results and error handling.

### Usage and Integration
This interacts with the serializer to introduce a layer of validation to check for inappropriate words in specific fields like name, title, message, and description.

### Testing
Testing was done in the front end by using inappropriate words in the specific fields mentioned above. I tried using "crap" and even changing the way certain letters are capitalized such as doing "cRaP". I also tried combining other words or letters around the word, such as "FeelingLikeCrapToday". All these word combinations and trials gave errors because an inappropriate word was used, which is good.

### Mentions
N/A